### PR TITLE
Align manifest version with tag

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -27,7 +27,7 @@ dockers:
   build_flag_templates:
   - "--platform=linux/arm64"
 docker_manifests:
-- name_template: absaoss/k8s_crd:{{ .Version }}
+- name_template: absaoss/k8s_crd:{{ .Tag }}
   image_templates:
   - absaoss/k8s_crd:{{ .Tag }}-amd64
   - absaoss/k8s_crd:{{ .Tag }}-arm64


### PR DESCRIPTION
While switching from .Version to .Tag main multiarch docker manifest was
forgotten to be updated. Fix it now.

Signed-off-by: Dinar Valeev <dinar.valeev@absa.africa>